### PR TITLE
Update Nokogiri gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
       robotex (>= 1.0.0)
     diffy (3.3.0)
     mini_portile2 (2.4.0)
-    nokogiri (1.10.1)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     robotex (1.0.0)
 


### PR DESCRIPTION
Addresses "CVE-2019-5477 High severity" vulnerability in Nokogiri.